### PR TITLE
Reverted JSON.NET version from 12.0.2 to 11.0.2

### DIFF
--- a/Solutions/Corvus.ContentHandling.Json/Corvus.ContentHandling.Json.csproj
+++ b/Solutions/Corvus.ContentHandling.Json/Corvus.ContentHandling.Json.csproj
@@ -15,7 +15,7 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.2.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Solutions/Corvus.ContentHandling.Json/Microsoft/Extensions/DependencyInjection/DefaultJsonSerializationSettingsServiceCollectionExtensions.cs
+++ b/Solutions/Corvus.ContentHandling.Json/Microsoft/Extensions/DependencyInjection/DefaultJsonSerializationSettingsServiceCollectionExtensions.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton<JsonConverter, CultureInfoConverter>();
             services.AddSingleton<JsonConverter, DateTimeOffsetConverter>();
             services.AddSingleton<JsonConverter, PropertyBagConverter>();
-            services.AddSingleton<JsonConverter>(new StringEnumConverter(new CamelCaseNamingStrategy()));
+            services.AddSingleton<JsonConverter>(new StringEnumConverter(true));
             services.AddSingleton<IDefaultJsonSerializerSettings, DefaultJsonSerializerSettings>();
             return services;
         }


### PR DESCRIPTION
Fixes #10. This was necessary to support the Azure Functions Runtime.