### PR TITLE
Initial basic support for constructor initialization

### DIFF
--- a/Solutions/Corvus.ContentHandling.Json.Specs/Corvus.ContentHandling.Json.Specs.csproj
+++ b/Solutions/Corvus.ContentHandling.Json.Specs/Corvus.ContentHandling.Json.Specs.csproj
@@ -1,5 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="$(EndjinProjectPropsPath)" Condition="$(EndjinProjectPropsPath) != ''" />
+
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
@@ -15,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="Corvus.SpecFlow.Extensions" Version="0.6.0" />
-    <PackageReference Include="Endjin.RecommendedPractices" Version="0.1.0">
+    <PackageReference Include="Endjin.RecommendedPractices" Version="0.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Solutions/Corvus.ContentHandling.Json.Specs/Corvus.ContentHandling.Json.Specs.csproj
+++ b/Solutions/Corvus.ContentHandling.Json.Specs/Corvus.ContentHandling.Json.Specs.csproj
@@ -21,16 +21,16 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="SpecFlow" Version="3.1.80" />
-    <PackageReference Include="SpecFlow.NUnit" Version="3.1.80" />
-    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.1.80" />
+    <PackageReference Include="SpecFlow" Version="3.1.97" />
+    <PackageReference Include="SpecFlow.NUnit" Version="3.1.97" />
+    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.1.97" />
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="coverlet.msbuild" Version="2.8.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="coverlet.msbuild" Version="2.8.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/Solutions/Corvus.ContentHandling.Json.Specs/DeserializingContent.feature
+++ b/Solutions/Corvus.ContentHandling.Json.Specs/DeserializingContent.feature
@@ -109,6 +109,11 @@ Scenario: Deserialize a polymorphic content object implementing a common abstrac
 	| Hello     | {child} |
 
 @useChildObjects
+Scenario: Deserialize a polymorphic content object implementing a common abstract base with a POC child object via constructor initialization
+	When I deserialize the json object '{ "contentType": "application/vnd.corvus.somecontentwithabstractbaseandpocchildctorinit", "someValue": "Hello", "child": { "someValue": "Dolly" } }' to the common abstract base as 'result'
+	Then the value called 'result' should match the content object implementing a common abstract base with a POC child object via constructor with value 'Hello', and child some value 'Dolly'
+
+@useChildObjects
 Scenario: Deserialize an object with a dictionary
 	Given I have a dictionary called 'dictionary' with values
 	| Key  | Value   |

--- a/Solutions/Corvus.ContentHandling.Json.Specs/DeserializingContent.feature.cs
+++ b/Solutions/Corvus.ContentHandling.Json.Specs/DeserializingContent.feature.cs
@@ -697,6 +697,51 @@ this.ScenarioInitialize(scenarioInfo);
         }
         
         [NUnit.Framework.TestAttribute()]
+        [NUnit.Framework.DescriptionAttribute("Deserialize a polymorphic content object implementing a common abstract base with" +
+            " a POC child object via constructor initialization")]
+        [NUnit.Framework.CategoryAttribute("useChildObjects")]
+        public virtual void DeserializeAPolymorphicContentObjectImplementingACommonAbstractBaseWithAPOCChildObjectViaConstructorInitialization()
+        {
+            string[] tagsOfScenario = new string[] {
+                    "useChildObjects"};
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Deserialize a polymorphic content object implementing a common abstract base with" +
+                    " a POC child object via constructor initialization", null, new string[] {
+                        "useChildObjects"});
+#line 112
+this.ScenarioInitialize(scenarioInfo);
+#line hidden
+            bool isScenarioIgnored = default(bool);
+            bool isFeatureIgnored = default(bool);
+            if ((tagsOfScenario != null))
+            {
+                isScenarioIgnored = tagsOfScenario.Where(__entry => __entry != null).Where(__entry => String.Equals(__entry, "ignore", StringComparison.CurrentCultureIgnoreCase)).Any();
+            }
+            if ((this._featureTags != null))
+            {
+                isFeatureIgnored = this._featureTags.Where(__entry => __entry != null).Where(__entry => String.Equals(__entry, "ignore", StringComparison.CurrentCultureIgnoreCase)).Any();
+            }
+            if ((isScenarioIgnored || isFeatureIgnored))
+            {
+                testRunner.SkipScenario();
+            }
+            else
+            {
+                this.ScenarioStart();
+#line 113
+ testRunner.When("I deserialize the json object \'{ \"contentType\": \"application/vnd.corvus.someconte" +
+                        "ntwithabstractbaseandpocchildctorinit\", \"someValue\": \"Hello\", \"child\": { \"someVa" +
+                        "lue\": \"Dolly\" } }\' to the common abstract base as \'result\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+#line 114
+ testRunner.Then("the value called \'result\' should match the content object implementing a common a" +
+                        "bstract base with a POC child object via constructor with value \'Hello\', and chi" +
+                        "ld some value \'Dolly\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
+            }
+            this.ScenarioCleanup();
+        }
+        
+        [NUnit.Framework.TestAttribute()]
         [NUnit.Framework.DescriptionAttribute("Deserialize an object with a dictionary")]
         [NUnit.Framework.CategoryAttribute("useChildObjects")]
         public virtual void DeserializeAnObjectWithADictionary()
@@ -705,7 +750,7 @@ this.ScenarioInitialize(scenarioInfo);
                     "useChildObjects"};
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Deserialize an object with a dictionary", null, new string[] {
                         "useChildObjects"});
-#line 112
+#line 117
 this.ScenarioInitialize(scenarioInfo);
 #line hidden
             bool isScenarioIgnored = default(bool);
@@ -737,10 +782,10 @@ this.ScenarioInitialize(scenarioInfo);
                 table19.AddRow(new string[] {
                             "key3",
                             "Value 3"});
-#line 113
+#line 118
  testRunner.Given("I have a dictionary called \'dictionary\' with values", ((string)(null)), table19, "Given ");
 #line hidden
-#line 118
+#line 123
  testRunner.When("I deserialize the json object \'{ \"someValue\": \"Hello\", \"dictionary\": { \"Key1\": \"V" +
                         "alue 1\", \"KEY2\": \"Value 2\", \"key3\": \"Value 3\" } }\' as a poc object with dictiona" +
                         "ry as \'result\'", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
@@ -751,7 +796,7 @@ this.ScenarioInitialize(scenarioInfo);
                 table20.AddRow(new string[] {
                             "Hello",
                             "{dictionary}"});
-#line 119
+#line 124
  testRunner.Then("the value called \'result\' should match the poc object with dictionary", ((string)(null)), table20, "Then ");
 #line hidden
             }

--- a/Solutions/Corvus.ContentHandling.Json.Specs/DeserializingContentSteps.cs
+++ b/Solutions/Corvus.ContentHandling.Json.Specs/DeserializingContentSteps.cs
@@ -72,6 +72,19 @@ namespace Corvus.ContentHandling.Json.Specs
 
             Assert.AreEqual(expected, actual);
         }
+
+        [Then("the value called '(.*)' should match the content object implementing a common abstract base with a POC child object via constructor with value '(.*)', and child some value '(.*)'")]
+        public void ThenTheValueCalledShouldMatchTheContentObjectImplementingACommonAbstractBaseWithAPOCChildObjectViaConstructorWithValueAndChildSomeValue(
+            string instanceName, string value, string childValue)
+        {
+            var expected = new SomeContentWithAbstractBaseAndPocChildCtorInitialized(
+                value,
+                new PocObjectWithCtorInitialization(childValue));
+
+            object actual = this.scenarioContext.Get<object>(instanceName);
+
+            Assert.AreEqual(expected, actual);
+        }
     }
 }
 

--- a/Solutions/Corvus.ContentHandling.Json.Specs/Samples/PocObjectWithCtorInitialization.cs
+++ b/Solutions/Corvus.ContentHandling.Json.Specs/Samples/PocObjectWithCtorInitialization.cs
@@ -1,0 +1,16 @@
+﻿// <copyright file="PocObjectWithCtorInitialization.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+namespace Corvus.ContentHandling.Json.Specs.Samples
+{
+    public class PocObjectWithCtorInitialization
+    {
+        public PocObjectWithCtorInitialization(string someValue)
+        {
+            this.SomeValue = someValue;
+        }
+
+        public string SomeValue { get; }
+    }
+}

--- a/Solutions/Corvus.ContentHandling.Json.Specs/Samples/PocObjectWithDictionary.cs
+++ b/Solutions/Corvus.ContentHandling.Json.Specs/Samples/PocObjectWithDictionary.cs
@@ -76,7 +76,7 @@ namespace Corvus.ContentHandling.Json.Specs.Samples
         /// <inheritdoc />
         public override bool Equals(object obj)
         {
-            if (obj is PocObject sci)
+            if (obj is PocObjectWithDictionary sci)
             {
                 return this.Equals(sci);
             }

--- a/Solutions/Corvus.ContentHandling.Json.Specs/Samples/SerializationSampleContentServiceCollectionExtensions.cs
+++ b/Solutions/Corvus.ContentHandling.Json.Specs/Samples/SerializationSampleContentServiceCollectionExtensions.cs
@@ -21,6 +21,7 @@ namespace Corvus.ContentHandling
             contentFactory.RegisterTransientContent<SomeContentWithInterface>();
             contentFactory.RegisterTransientContent<SomeContentWithInterfaceAndChild>();
             contentFactory.RegisterTransientContent<SomeContentWithInterfaceAndPocChild>();
+            contentFactory.RegisterContent<SomeContentWithAbstractBaseAndPocChildCtorInitialized>();
 
             contentFactory.RegisterTransientContent<SomeContentWithAbstractBase>();
             contentFactory.RegisterTransientContent<SomeContentWithAbstractBaseAndChild>();

--- a/Solutions/Corvus.ContentHandling.Json.Specs/Samples/SomeContentWithAbstractBaseAndPocChild.cs
+++ b/Solutions/Corvus.ContentHandling.Json.Specs/Samples/SomeContentWithAbstractBaseAndPocChild.cs
@@ -77,7 +77,7 @@ namespace Corvus.ContentHandling.Json.Specs.Samples
         /// <inheritdoc/>
         public override int GetHashCode()
         {
-            return (this.SomeValue, this.Child).GetHashCode();
+            return HashCode.Combine(this.SomeValue, this.Child);
         }
     }
 }

--- a/Solutions/Corvus.ContentHandling.Json.Specs/Samples/SomeContentWithAbstractBaseAndPocChildCtorInitialized.cs
+++ b/Solutions/Corvus.ContentHandling.Json.Specs/Samples/SomeContentWithAbstractBaseAndPocChildCtorInitialized.cs
@@ -1,0 +1,96 @@
+﻿// <copyright file="SomeContentWithAbstractBaseAndPocChildCtorInitialized.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+namespace Corvus.ContentHandling.Json.Specs.Samples
+{
+    using System;
+
+    /// <summary>
+    /// A polymorphic content type based on an abstract base.
+    /// </summary>
+    public class SomeContentWithAbstractBaseAndPocChildCtorInitialized : SomeContentAbstractBase, IEquatable<SomeContentWithAbstractBaseAndPocChildCtorInitialized>
+    {
+        /// <summary>
+        /// The content type.
+        /// </summary>
+        public const string RegisteredContentType = "application/vnd.corvus.somecontentwithabstractbaseandpocchildctorinit";
+
+        /// <summary>
+        /// Creates a <see cref="SomeContentWithAbstractBaseAndPocChildCtorInitialized"/>.
+        /// </summary>
+        /// <param name="someValue"><see cref="SomeValue"/>.</param>
+        /// <param name="child"><see cref="Child"/>.</param>
+        public SomeContentWithAbstractBaseAndPocChildCtorInitialized(
+            string someValue,
+            PocObjectWithCtorInitialization child)
+        {
+            this.SomeValue = someValue;
+            this.Child = child;
+        }
+
+        /// <inheritdoc/>
+        public override string ContentType => RegisteredContentType;
+
+        /// <summary>
+        /// Gets a value.
+        /// </summary>
+        public string SomeValue { get; }
+
+        /// <summary>
+        /// Gets a child.
+        /// </summary>
+        public PocObjectWithCtorInitialization Child { get; }
+
+        /// <summary>
+        /// Compares two instances of <see cref="SomeContentWithAbstractBaseAndPocChildCtorInitialized"/> for equality.
+        /// </summary>
+        /// <param name="left">The first object to compare.</param>
+        /// <param name="right">The second object to compare.</param>
+        /// <returns>True if the instances are equal, false otherwise.</returns>
+        public static bool operator ==(SomeContentWithAbstractBaseAndPocChildCtorInitialized left, SomeContentWithAbstractBaseAndPocChildCtorInitialized right)
+        {
+            return left?.Equals(right) ?? false;
+        }
+
+        /// <summary>
+        /// Compares two instances of <see cref="SomeContentWithAbstractBaseAndPocChildCtorInitialized"/> for inequality.
+        /// </summary>
+        /// <param name="left">The first object to compare.</param>
+        /// <param name="right">The second object to compare.</param>
+        /// <returns>False if the instances are equal, true otherwise.</returns>
+        public static bool operator !=(SomeContentWithAbstractBaseAndPocChildCtorInitialized left, SomeContentWithAbstractBaseAndPocChildCtorInitialized right)
+        {
+            return !(left == right);
+        }
+
+        /// <inheritdoc />
+        public bool Equals(SomeContentWithAbstractBaseAndPocChildCtorInitialized other)
+        {
+            return this.SomeValue == other.SomeValue;
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(SomeContentAbstractBase other)
+        {
+            return this.Equals(other as SomeContentWithAbstractBaseAndPocChildCtorInitialized);
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object obj)
+        {
+            if (obj is SomeContentWithAbstractBaseAndPocChildCtorInitialized sci)
+            {
+                return this.Equals(sci);
+            }
+
+            return false;
+        }
+
+        /// <inheritdoc/>
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(this.SomeValue, this.Child);
+        }
+    }
+}

--- a/Solutions/Corvus.ContentHandling.Json/Corvus.ContentHandling.Json.csproj
+++ b/Solutions/Corvus.ContentHandling.Json/Corvus.ContentHandling.Json.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Corvus.Extensions.Newtonsoft.Json" Version="0.10.0-PullRequest0087.16" />
+    <PackageReference Include="Corvus.Extensions.Newtonsoft.Json" Version="0.10.0-PullRequest0087.17" />
     <PackageReference Include="Endjin.RecommendedPractices" Version="0.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Solutions/Corvus.ContentHandling.Json/Corvus.ContentHandling.Json.csproj
+++ b/Solutions/Corvus.ContentHandling.Json/Corvus.ContentHandling.Json.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Corvus.Extensions.Newtonsoft.Json" Version="0.9.0" />
+    <PackageReference Include="Corvus.Extensions.Newtonsoft.Json" Version="0.10.0-PullRequest0087.16" />
     <PackageReference Include="Endjin.RecommendedPractices" Version="0.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Solutions/Corvus.ContentHandling.Json/Corvus.ContentHandling.Json.csproj
+++ b/Solutions/Corvus.ContentHandling.Json/Corvus.ContentHandling.Json.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Corvus.Extensions.Newtonsoft.Json" Version="0.10.0-PullRequest0087.17" />
+    <PackageReference Include="Corvus.Extensions.Newtonsoft.Json" Version="0.10.0" />
     <PackageReference Include="Endjin.RecommendedPractices" Version="0.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Solutions/Corvus.ContentHandling.Json/Corvus.ContentHandling.Json.csproj
+++ b/Solutions/Corvus.ContentHandling.Json/Corvus.ContentHandling.Json.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="$(EndjinProjectPropsPath)" Condition="$(EndjinProjectPropsPath) != ''" />
+
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <RootNamespace />
   </PropertyGroup>
 
   <PropertyGroup>
@@ -14,7 +15,7 @@
   
   <ItemGroup>
     <PackageReference Include="Corvus.Extensions.Newtonsoft.Json" Version="0.10.0-PullRequest0087.17" />
-    <PackageReference Include="Endjin.RecommendedPractices" Version="0.1.0">
+    <PackageReference Include="Endjin.RecommendedPractices" Version="0.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Solutions/Corvus.ContentHandling.Json/Corvus/ContentHandling/Json/ContentEnvelope.cs
+++ b/Solutions/Corvus.ContentHandling.Json/Corvus/ContentHandling/Json/ContentEnvelope.cs
@@ -7,7 +7,6 @@ namespace Corvus.ContentHandling.Json
     using System;
     using System.IO;
     using System.Threading.Tasks;
-    using Corvus.Extensions.Json.Internal;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;
 

--- a/Solutions/Corvus.ContentHandling.Json/Corvus/ContentHandling/Json/Internal/ContentTypeConverter.cs
+++ b/Solutions/Corvus.ContentHandling.Json/Corvus/ContentHandling/Json/Internal/ContentTypeConverter.cs
@@ -6,6 +6,7 @@ namespace Corvus.ContentHandling.Json.Internal
 {
     using System;
     using System.Reflection;
+    using System.Threading;
     using Microsoft.Extensions.DependencyInjection;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Converters;
@@ -38,6 +39,7 @@ namespace Corvus.ContentHandling.Json.Internal
     public class ContentTypeConverter : CustomCreationConverter<object>
     {
         private readonly IServiceProvider serviceProvider;
+        private readonly ThreadLocal<Type> skipType = new ThreadLocal<Type>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ContentTypeConverter"/> class.
@@ -57,6 +59,12 @@ namespace Corvus.ContentHandling.Json.Internal
         /// <inheritdoc/>
         public override bool CanConvert(Type objectType)
         {
+            if (this.skipType.IsValueCreated && objectType == this.skipType.Value)
+            {
+                this.skipType.Value = null;
+                return false;
+            }
+
             PropertyInfo member = objectType.GetTypeInfo().GetProperty("ContentType", BindingFlags.Public | BindingFlags.Instance);
 
             return member != null;
@@ -92,9 +100,7 @@ namespace Corvus.ContentHandling.Json.Internal
 
             string contentType = (string)jo["contentType"];
 
-            object result = this.serviceProvider.GetContent(contentType);
-
-            if (result is null)
+            if (!this.serviceProvider.TryGetTypeFor(contentType, out Type type))
             {
                 throw new InvalidOperationException($"The content for type {contentType} has not been registered with the ContentFactory.");
             }
@@ -109,9 +115,31 @@ namespace Corvus.ContentHandling.Json.Internal
             contentReader.MaxDepth = reader.MaxDepth;
             contentReader.SupportMultipleContent = reader.SupportMultipleContent;
 
-            serializer.Populate(contentReader, result);
-
-            return result;
+            // Having established the correct target type based on the content type property, we
+            // want to get JSON.NET to do the work for us. We used to do this by constructing an
+            // instance and then calling serializer.Populate, but that prevented constructor-based
+            // initialization from working. So we want to defer even the object creation to
+            // JSON.NET. However, since we're just asking it again to do the thing it was
+            // already doing, it'll invoke our type converter a second time, leading to infinite
+            // recursion. And we can't just build a separate JSON settings object with this type
+            // converter removed, because we need it to remain in place to be able to handle any
+            // nested objects—we want recursion in those cases. To avoid recursion for the object
+            // we're on right now, we want our CanConvert method to return false on the call that
+            // we know is about to come in. So we set a thread-local value tracking the fact that
+            // we're expecting a second call for this type that we should ignore. Our CanConvert
+            // detects that call, resets this thread-local value and then returns false, ensuring
+            // that nested conversions can still occur.
+            try
+            {
+                this.skipType.Value = type;
+                return serializer.Deserialize(contentReader, type);
+            }
+            finally
+            {
+                // Clear this just in case—cleanup semantics around long-lived ThreadLocal<T>
+                // instances are a little unclear.
+                this.skipType.Value = null;
+            }
         }
 
         /// <inheritdoc/>

--- a/Solutions/Corvus.ContentHandling.Specs/Corvus.ContentHandling.Specs.csproj
+++ b/Solutions/Corvus.ContentHandling.Specs/Corvus.ContentHandling.Specs.csproj
@@ -20,17 +20,17 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.1" />
-    <PackageReference Include="SpecFlow" Version="3.1.80" />
-    <PackageReference Include="SpecFlow.NUnit" Version="3.1.80" />
-    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.1.80" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.3" />
+    <PackageReference Include="SpecFlow" Version="3.1.97" />
+    <PackageReference Include="SpecFlow.NUnit" Version="3.1.97" />
+    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.1.97" />
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="coverlet.msbuild" Version="2.8.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="coverlet.msbuild" Version="2.8.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/Solutions/Corvus.ContentHandling.Specs/Corvus.ContentHandling.Specs.csproj
+++ b/Solutions/Corvus.ContentHandling.Specs/Corvus.ContentHandling.Specs.csproj
@@ -1,8 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="$(EndjinProjectPropsPath)" Condition="$(EndjinProjectPropsPath) != ''" />
+
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
+    <RootNamespace>Corvus.ContentHandling.Specs</RootNamespace>
     <!-- Disabling SA1204 because it prioritizes static/non-static over public/non-public, which doesn't fit very well
          with bindings in SpecFlow.
          Disabling SA1600, SA1602 (all public types and members to be documented) because test projects need to make lots of types
@@ -13,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Endjin.RecommendedPractices" Version="0.1.0">
+    <PackageReference Include="Endjin.RecommendedPractices" Version="0.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Solutions/Corvus.ContentHandling/Corvus.ContentHandling.csproj
+++ b/Solutions/Corvus.ContentHandling/Corvus.ContentHandling.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="$(EndjinProjectPropsPath)" Condition="$(EndjinProjectPropsPath) != ''" />
+
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <RootNamespace />
   </PropertyGroup>
 
   <PropertyGroup>
@@ -13,7 +14,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Endjin.RecommendedPractices" Version="0.1.0">
+    <PackageReference Include="Endjin.RecommendedPractices" Version="0.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Solutions/Corvus.ContentHandling/Corvus/ContentHandling/ContentFactoryExtensions.cs
+++ b/Solutions/Corvus.ContentHandling/Corvus/ContentHandling/ContentFactoryExtensions.cs
@@ -48,6 +48,49 @@ namespace Corvus.ContentHandling
         }
 
         /// <summary>
+        /// Register an implementation type for a content type that does not depend on services, and which
+        /// can be initialized directly through deserialization.
+        /// </summary>
+        /// <typeparam name="T">The type to register.</typeparam>
+        /// <param name="contentFactory">The content registry for this factory.</param>
+        /// <remarks>The type must provide a static/const string called. <c>RegisteredContentType</c> which defines its content type.</remarks>
+        public static void RegisterContent<T>(this ContentFactory contentFactory)
+            where T : class
+        {
+            if (contentFactory == null)
+            {
+                throw new ArgumentNullException(nameof(contentFactory));
+            }
+
+            string contentType = ContentFactory.GetContentType(typeof(T));
+
+            contentFactory.AddSimpleDeserializableType(contentType, typeof(T));
+        }
+
+        /// <summary>
+        /// Register an implementation type for a content type that does not depend on services, and which
+        /// can be initialized directly through deserialization.
+        /// </summary>
+        /// <typeparam name="T">The type to register.</typeparam>
+        /// <param name="contentFactory">The content registry for this factory.</param>
+        /// <param name="contentType">The content type by which to register it.</param>
+        public static void RegisterContent<T>(this ContentFactory contentFactory, string contentType)
+            where T : class
+        {
+            if (contentFactory == null)
+            {
+                throw new ArgumentNullException(nameof(contentFactory));
+            }
+
+            if (string.IsNullOrEmpty(contentType))
+            {
+                throw new ArgumentNullException(nameof(contentType));
+            }
+
+            contentFactory.AddSimpleDeserializableType(contentType, typeof(T));
+        }
+
+        /// <summary>
         /// Register a single instance for the specified type and content type.
         /// </summary>
         /// <typeparam name="T">The type to register.</typeparam>
@@ -66,10 +109,7 @@ namespace Corvus.ContentHandling
                 throw new ArgumentNullException(nameof(contentType));
             }
 
-            if (!contentFactory.Handlers.TryAdd(contentType, typeof(T)))
-            {
-                throw new InvalidOperationException(string.Format(Resources.NamedTypeAlreadyAdded, contentType));
-            }
+            contentFactory.AddTypeRequiringServices(contentType, typeof(T));
 
             if (!contentFactory.Services.Any(s => s.ServiceType == typeof(T)))
             {
@@ -127,10 +167,7 @@ namespace Corvus.ContentHandling
                 throw new ArgumentNullException(nameof(implementationFactory));
             }
 
-            if (!contentFactory.Handlers.TryAdd(contentType, typeof(T)))
-            {
-                throw new InvalidOperationException(string.Format(Resources.NamedTypeAlreadyAdded, contentType));
-            }
+            contentFactory.AddTypeRequiringServices(contentType, typeof(T));
 
             if (!contentFactory.Services.Any(s => s.ServiceType == typeof(T)))
             {
@@ -188,10 +225,7 @@ namespace Corvus.ContentHandling
                 throw new ArgumentNullException(nameof(implementationInstance));
             }
 
-            if (!contentFactory.Handlers.TryAdd(contentType, typeof(T)))
-            {
-                throw new InvalidOperationException(string.Format(Resources.NamedTypeAlreadyAdded, contentType));
-            }
+            contentFactory.AddTypeRequiringServices(contentType, typeof(T));
 
             if (!contentFactory.Services.Any(s => s.ServiceType == typeof(T)))
             {
@@ -245,10 +279,7 @@ namespace Corvus.ContentHandling
                 throw new ArgumentNullException(nameof(serviceType));
             }
 
-            if (!contentFactory.Handlers.TryAdd(contentType, serviceType))
-            {
-                throw new InvalidOperationException(string.Format(Resources.NamedTypeAlreadyAdded, contentType));
-            }
+            contentFactory.AddTypeRequiringServices(contentType, serviceType);
 
             if (!contentFactory.Services.Any(s => s.ServiceType == serviceType))
             {
@@ -316,10 +347,7 @@ namespace Corvus.ContentHandling
                 throw new ArgumentNullException(nameof(implementationFactory));
             }
 
-            if (!contentFactory.Handlers.TryAdd(contentType, serviceType))
-            {
-                throw new InvalidOperationException(string.Format(Resources.NamedTypeAlreadyAdded, contentType));
-            }
+            contentFactory.AddTypeRequiringServices(contentType, serviceType);
 
             if (!contentFactory.Services.Any(s => s.ServiceType == serviceType))
             {
@@ -384,10 +412,7 @@ namespace Corvus.ContentHandling
                 throw new ArgumentNullException(nameof(implementationInstance));
             }
 
-            if (!contentFactory.Handlers.TryAdd(contentType, serviceType))
-            {
-                throw new InvalidOperationException(string.Format(Resources.NamedTypeAlreadyAdded, contentType));
-            }
+            contentFactory.AddTypeRequiringServices(contentType, serviceType);
 
             if (!contentFactory.Services.Any(s => s.ServiceType == serviceType))
             {
@@ -436,10 +461,7 @@ namespace Corvus.ContentHandling
                 throw new ArgumentNullException(nameof(contentType));
             }
 
-            if (!contentFactory.Handlers.TryAdd(contentType, typeof(T)))
-            {
-                throw new InvalidOperationException(string.Format(Resources.NamedTypeAlreadyAdded, contentType));
-            }
+            contentFactory.AddTypeRequiringServices(contentType, typeof(T));
 
             if (!contentFactory.Services.Any(s => s.ServiceType == typeof(T)))
             {
@@ -497,10 +519,7 @@ namespace Corvus.ContentHandling
                 throw new ArgumentNullException(nameof(implementationFactory));
             }
 
-            if (!contentFactory.Handlers.TryAdd(contentType, typeof(T)))
-            {
-                throw new InvalidOperationException(string.Format(Resources.NamedTypeAlreadyAdded, contentType));
-            }
+            contentFactory.AddTypeRequiringServices(contentType, typeof(T));
 
             if (!contentFactory.Services.Any(s => s.ServiceType == typeof(T)))
             {
@@ -550,10 +569,7 @@ namespace Corvus.ContentHandling
                 throw new ArgumentNullException(nameof(contentType));
             }
 
-            if (!contentFactory.Handlers.TryAdd(contentType, serviceType))
-            {
-                throw new InvalidOperationException(string.Format(Resources.NamedTypeAlreadyAdded, contentType));
-            }
+            contentFactory.AddTypeRequiringServices(contentType, serviceType);
 
             if (serviceType == null)
             {
@@ -624,10 +640,7 @@ namespace Corvus.ContentHandling
                 throw new ArgumentNullException(nameof(implementationFactory));
             }
 
-            if (!contentFactory.Handlers.TryAdd(contentType, serviceType))
-            {
-                throw new InvalidOperationException(string.Format(Resources.NamedTypeAlreadyAdded, contentType));
-            }
+            contentFactory.AddTypeRequiringServices(contentType, serviceType);
 
             if (!contentFactory.Services.Any(s => s.ServiceType == serviceType))
             {
@@ -673,10 +686,7 @@ namespace Corvus.ContentHandling
                 throw new ArgumentNullException(nameof(contentType));
             }
 
-            if (!contentFactory.Handlers.TryAdd(contentType, typeof(T)))
-            {
-                throw new InvalidOperationException(string.Format(Resources.NamedTypeAlreadyAdded, contentType));
-            }
+            contentFactory.AddTypeRequiringServices(contentType, typeof(T));
 
             if (!contentFactory.Services.Any(s => s.ServiceType == typeof(T)))
             {
@@ -734,10 +744,7 @@ namespace Corvus.ContentHandling
                 throw new ArgumentNullException(nameof(implementationFactory));
             }
 
-            if (!contentFactory.Handlers.TryAdd(contentType, typeof(T)))
-            {
-                throw new InvalidOperationException(string.Format(Resources.NamedTypeAlreadyAdded, contentType));
-            }
+            contentFactory.AddTypeRequiringServices(contentType, typeof(T));
 
             if (!contentFactory.Services.Any(s => s.ServiceType == typeof(T)))
             {
@@ -786,10 +793,7 @@ namespace Corvus.ContentHandling
                 throw new ArgumentNullException(nameof(contentType));
             }
 
-            if (!contentFactory.Handlers.TryAdd(contentType, serviceType))
-            {
-                throw new InvalidOperationException(string.Format(Resources.NamedTypeAlreadyAdded, contentType));
-            }
+            contentFactory.AddTypeRequiringServices(contentType, serviceType);
 
             if (serviceType == null)
             {
@@ -860,10 +864,7 @@ namespace Corvus.ContentHandling
                 throw new ArgumentNullException(nameof(implementationFactory));
             }
 
-            if (!contentFactory.Handlers.TryAdd(contentType, serviceType))
-            {
-                throw new InvalidOperationException(string.Format(Resources.NamedTypeAlreadyAdded, contentType));
-            }
+            contentFactory.AddTypeRequiringServices(contentType, serviceType);
 
             if (!contentFactory.Services.Any(s => s.ServiceType == serviceType))
             {

--- a/Solutions/Corvus.ContentHandling/Corvus/ContentHandling/IContentHandlerDispatcher{TPayloadBaseType}.cs
+++ b/Solutions/Corvus.ContentHandling/Corvus/ContentHandling/IContentHandlerDispatcher{TPayloadBaseType}.cs
@@ -6,7 +6,6 @@ namespace Corvus.ContentHandling
 {
     using System;
     using System.Threading.Tasks;
-    using Microsoft.Extensions.DependencyInjection;
 
     /// <summary>
     /// An interface implemented by types which can dispatch a payload

--- a/Solutions/Corvus.ContentHandling/Corvus/ContentHandling/Internal/ContentHandlerGenerator.cs
+++ b/Solutions/Corvus.ContentHandling/Corvus/ContentHandling/Internal/ContentHandlerGenerator.cs
@@ -13,7 +13,6 @@ namespace Corvus.ContentHandling.Internal
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
-    using Microsoft.Extensions.DependencyInjection;
 
     /// <summary>
     /// Registers custom subclasses of the <see cref="IContentHandler{TPayloadType}"/>

--- a/Solutions/Corvus.ContentHandling/Corvus/ContentHandling/Resources.Designer.cs
+++ b/Solutions/Corvus.ContentHandling/Corvus/ContentHandling/Resources.Designer.cs
@@ -61,6 +61,15 @@ namespace Corvus.ContentHandling {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The implementing type ({0}) for content type {1} uses constructor-based deserialization, so you cannot instantiate it in this way.
+        /// </summary>
+        internal static string ImplementingTypeNoDefaultCtor {
+            get {
+                return ResourceManager.GetString("ImplementingTypeNoDefaultCtor", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The service named &apos;{0}&apos; is not assignable to type &apos;{1}&apos;..
         /// </summary>
         internal static string NamedServiceNotOfType {

--- a/Solutions/Corvus.ContentHandling/Corvus/ContentHandling/Resources.resx
+++ b/Solutions/Corvus.ContentHandling/Corvus/ContentHandling/Resources.resx
@@ -134,4 +134,8 @@
     <value>No service for type '{0}' has been registered.</value>
     <comment>{0} = service type</comment>
   </data>
+  <data name="ImplementingTypeNoDefaultCtor" xml:space="preserve">
+    <value>The implementing type ({0}) for content type {1} uses constructor-based deserialization, so you cannot instantiate it in this way</value>
+    <comment>{0} = implementation type, {1} = content type</comment>
+  </data>
 </root>


### PR DESCRIPTION
Resolves #96 

Added new `RegisterContent` which enables a content type to be registered with an implementing type that does not require services from DI. When types are registered in this way, they can used constructor-based deserialization.

This also renames an extremely misleadingly-named internal property: `ContentFactory.Handlers` was not in fact a collection of handlers. It was a list of collection of registered content types (some of which might be handlers).