### PR TITLE
Remove content registration callback param from registration method

### DIFF
--- a/Solutions/Corvus.ContentHandling.Json.Specs/ContentHandlingContainerBindings.cs
+++ b/Solutions/Corvus.ContentHandling.Json.Specs/ContentHandlingContainerBindings.cs
@@ -24,8 +24,11 @@ namespace Corvus.ContentHandling
         {
             ContainerBindings.ConfigureServices(
                 featureContext,
-                serviceCollection => serviceCollection.AddContentTypeBasedSerializationSupport(
-                    contentFactory => contentFactory.AddSampleContent()));
+                serviceCollection =>
+                {
+                    serviceCollection.AddContentTypeBasedSerializationSupport();
+                    serviceCollection.AddContent(contentFactory => contentFactory.AddSampleContent());
+                });
         }
     }
 }


### PR DESCRIPTION
The `AddContentTypeBasedSerializationSupport` method added in the previous PR to take into account changes in Corvus.Extensions.Newtonsoft.Json carried forward an existing problem with registration. Both the previous and new method allowed a `configure` callback parameter to be supplied, allowing the caller to add content type registration to the function call.

The problem with this approach is that due to the checks we do to ensure we don't accidentally register a service twice, multiple calls to `AddContentTypeBasedSerializationSupport` could be made from different areas of code, each supplying a different `configure` callback, and only the first would be executed. Subsequent invocations would detect that services had already been registered and exit without executing the supplied callback.

To make this more obvious we've removed the `configure` parameter and added xmldoc comments to tell consumers to explicitly call the `IServiceCollection.AddContent` method to register their content.