### PR TITLE
Fix messed up JSON in workflow test matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,13 +67,7 @@ jobs:
       testPhaseMatrixJson: |
         {
           "os": ["windows-latest", "ubuntu-latest"],
-          "dotnetFramework": ["net8.0", "net9.0", "net481"],
-          "exclude": [
-            {
-              "os": "ubuntu-latest",
-              "dotnetFramework": "net481"
-            }
-          ]
+          "dotnetFramework": ["net8.0", "net9.0"]
         }
       # testArtifactName: ''
       # testArtifactPath: ''

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,10 +69,11 @@ jobs:
           "os": ["windows-latest", "ubuntu-latest"],
           "dotnetFramework": ["net8.0", "net9.0", "net481"],
           "exclude": [
-          {
-            "os": "ubuntu-latest",
-            "dotnetFramework": "net481"
-          }
+            {
+              "os": "ubuntu-latest",
+              "dotnetFramework": "net481"
+            }
+          ]
         }
       # testArtifactName: ''
       # testArtifactPath: ''


### PR DESCRIPTION
Somehow missed that the previous PR had a missing close square bracket in the testPhaseMatrixJson

Not clear why that didn't cause the PR to be rejected.